### PR TITLE
tics auth token lowercasing (juju secret no caps issue)

### DIFF
--- a/tics_installer.sh
+++ b/tics_installer.sh
@@ -32,7 +32,7 @@ chmod 0440 /etc/sudoers.d/$USRNAME
 # Switch to the new user
 sudo -i -u $USRNAME bash << EOF
 
-export TICSAUTHTOKEN=$TICSAUTHTOKEN
+export TICSAUTHTOKEN=$ticsauthtoken
 
 # Download and install TiCS
 curl -o /home/$USRNAME/install_tics.sh -L "https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/"


### PR DESCRIPTION
Juju secrets do not support UPPERCASE (weird...). Change the variable to be lowercased for the time being.